### PR TITLE
Add parallel multi-account usage checks

### DIFF
--- a/claude_usage.py
+++ b/claude_usage.py
@@ -5,13 +5,24 @@ session via a virtual terminal (pexpect + pyte). This is the only reliable
 method — there is no public API endpoint for usage data.
 
 Usage as a library:
-    from claude_usage import get_usage
+    from claude_usage import get_usage, get_usage_multi
+
+    # Single account
     usage = get_usage()                             # default ~/.claude
     usage = get_usage("/home/me/.claude-work")      # specific profile
+
+    # Multiple accounts in parallel
+    results = get_usage_multi([
+        "/home/me/.claude-profiles/acct-a/.claude",
+        "/home/me/.claude-profiles/acct-b/.claude",
+    ])
+    for dir, usage in results.items():
+        print(f"{dir}: 5hr={usage.five_hour_pct}%")
 
 Usage as a CLI:
     claude-usage                                    # default
     claude-usage --claude-dir ~/.claude-work        # specific profile
+    claude-usage --claude-dir /path/a --claude-dir /path/b  # parallel
     claude-usage --json                             # JSON output
 """
 
@@ -24,6 +35,7 @@ import re
 import shutil
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
 from typing import Optional
 
@@ -209,6 +221,73 @@ def get_usage(claude_dir: Optional[str] = None, timeout: int = 60) -> Usage:
             pass
 
 
+def get_usage_multi(
+    claude_dirs: list[str],
+    timeout: int = 60,
+    max_workers: int | None = None,
+) -> dict[str, Usage | None]:
+    """Get usage for multiple accounts in parallel.
+
+    Each account is probed concurrently via its own pexpect/pyte session.
+    Individual failures return None without blocking other probes.
+
+    Args:
+        claude_dirs:  List of .claude config directory paths.
+        timeout:      Max seconds per probe (passed to get_usage).
+        max_workers:  Thread pool size. Defaults to min(len(claude_dirs), 4).
+
+    Returns:
+        Dict mapping each config dir to its Usage (or None on failure).
+    """
+    if not claude_dirs:
+        return {}
+
+    if max_workers is None:
+        max_workers = min(len(claude_dirs), 4)
+
+    results: dict[str, Usage | None] = {}
+
+    def _probe(claude_dir: str) -> tuple[str, Usage | None]:
+        try:
+            return claude_dir, get_usage(claude_dir=claude_dir, timeout=timeout)
+        except Exception:
+            return claude_dir, None
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_probe, d): d for d in claude_dirs}
+        for future in as_completed(futures):
+            claude_dir, usage = future.result()
+            results[claude_dir] = usage
+
+    return results
+
+
+def _print_usage(usage: Usage, label: str | None = None) -> bool:
+    """Pretty-print a single Usage result. Returns True if any data shown."""
+    if label:
+        print(f"\n--- {label} ---")
+    shown = False
+    if usage.five_hour_pct is not None:
+        print(f"Session (5h):     {usage.five_hour_pct:>5.0f}% used", end="")
+        if usage.five_hour_resets:
+            print(f"  (resets {usage.five_hour_resets})", end="")
+        print()
+        shown = True
+    if usage.seven_day_pct is not None:
+        print(f"Week (all):       {usage.seven_day_pct:>5.0f}% used", end="")
+        if usage.seven_day_resets:
+            print(f"  (resets {usage.seven_day_resets})", end="")
+        print()
+        shown = True
+    if usage.sonnet_week_pct is not None:
+        print(f"Week (Sonnet):    {usage.sonnet_week_pct:>5.0f}% used", end="")
+        if usage.sonnet_week_resets:
+            print(f"  (resets {usage.sonnet_week_resets})", end="")
+        print()
+        shown = True
+    return shown
+
+
 def main():
     import argparse
 
@@ -217,7 +296,8 @@ def main():
     )
     parser.add_argument(
         "--claude-dir",
-        help="Path to .claude config directory (default: ~/.claude)",
+        action="append",
+        help="Path to .claude config directory (repeatable for multi-account)",
     )
     parser.add_argument(
         "--json", action="store_true", dest="as_json",
@@ -225,36 +305,46 @@ def main():
     )
     args = parser.parse_args()
 
+    dirs = args.claude_dir  # None or list of strings
+
     try:
-        usage = get_usage(claude_dir=args.claude_dir)
+        if dirs and len(dirs) > 1:
+            # Multi-account parallel mode
+            results = get_usage_multi(dirs)
+            if args.as_json:
+                print(json.dumps(
+                    {d: u.to_dict() if u else None for d, u in results.items()},
+                    indent=2,
+                ))
+            else:
+                any_data = False
+                for d, usage in results.items():
+                    if usage is None:
+                        print(f"\n--- {d} ---")
+                        print("  Error: failed to retrieve usage")
+                    else:
+                        if _print_usage(usage, label=d):
+                            any_data = True
+                if not any_data:
+                    print("No usage data found for any account.")
+                    sys.exit(1)
+        else:
+            # Single-account mode (default or single --claude-dir)
+            claude_dir = dirs[0] if dirs else None
+            usage = get_usage(claude_dir=claude_dir)
+
+            if args.as_json:
+                print(json.dumps(usage.to_dict(), indent=2))
+            else:
+                if not _print_usage(usage):
+                    print("No usage data found. Is Claude Code installed and logged in?")
+                    sys.exit(1)
     except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
     except TimeoutError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
-
-    if args.as_json:
-        print(json.dumps(usage.to_dict(), indent=2))
-    else:
-        if usage.five_hour_pct is not None:
-            print(f"Session (5h):     {usage.five_hour_pct:>5.0f}% used", end="")
-            if usage.five_hour_resets:
-                print(f"  (resets {usage.five_hour_resets})", end="")
-            print()
-        if usage.seven_day_pct is not None:
-            print(f"Week (all):       {usage.seven_day_pct:>5.0f}% used", end="")
-            if usage.seven_day_resets:
-                print(f"  (resets {usage.seven_day_resets})", end="")
-            print()
-        if usage.sonnet_week_pct is not None:
-            print(f"Week (Sonnet):    {usage.sonnet_week_pct:>5.0f}% used", end="")
-            if usage.sonnet_week_resets:
-                print(f"  (resets {usage.sonnet_week_resets})", end="")
-            print()
-        if usage.five_hour_pct is None and usage.seven_day_pct is None:
-            print("No usage data found. Is Claude Code installed and logged in?")
-            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_claude_usage.py
+++ b/tests/test_claude_usage.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from claude_usage import Usage, _find_claude, _parse_screen, get_usage
+from claude_usage import Usage, _find_claude, _parse_screen, get_usage, get_usage_multi
 
 
 # ---------------------------------------------------------------------------
@@ -273,6 +273,132 @@ class TestGetUsageLive:
         assert isinstance(usage, Usage)
         # Should get real data because we copied valid credentials
         assert usage.five_hour_pct is not None or usage.seven_day_pct is not None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: get_usage_multi
+# ---------------------------------------------------------------------------
+
+
+class TestGetUsageMulti:
+    """Unit tests for get_usage_multi using mocked get_usage."""
+
+    def test_returns_dict_keyed_by_dir(self, monkeypatch):
+        fake_usage = Usage(five_hour_pct=42.0, seven_day_pct=10.0)
+        monkeypatch.setattr("claude_usage.get_usage", lambda claude_dir=None, timeout=60: fake_usage)
+
+        results = get_usage_multi(["/dir/a", "/dir/b"])
+        assert isinstance(results, dict)
+        assert set(results.keys()) == {"/dir/a", "/dir/b"}
+        for usage in results.values():
+            assert usage.five_hour_pct == 42.0
+
+    def test_individual_failure_returns_none(self, monkeypatch):
+        call_count = {"n": 0}
+
+        def flaky_get_usage(claude_dir=None, timeout=60):
+            call_count["n"] += 1
+            if call_count["n"] % 2 == 0:
+                raise TimeoutError("timed out")
+            return Usage(five_hour_pct=50.0)
+
+        monkeypatch.setattr("claude_usage.get_usage", flaky_get_usage)
+
+        results = get_usage_multi(["/dir/a", "/dir/b", "/dir/c"])
+        assert len(results) == 3
+        none_count = sum(1 for v in results.values() if v is None)
+        data_count = sum(1 for v in results.values() if v is not None)
+        # At least one should succeed and at least one should fail
+        assert none_count >= 1
+        assert data_count >= 1
+
+    def test_empty_list_returns_empty_dict(self):
+        results = get_usage_multi([])
+        assert results == {}
+
+    def test_single_dir_works(self, monkeypatch):
+        fake_usage = Usage(five_hour_pct=75.0)
+        monkeypatch.setattr("claude_usage.get_usage", lambda claude_dir=None, timeout=60: fake_usage)
+
+        results = get_usage_multi(["/only/one"])
+        assert len(results) == 1
+        assert results["/only/one"].five_hour_pct == 75.0
+
+    def test_max_workers_respected(self, monkeypatch):
+        fake_usage = Usage(five_hour_pct=10.0)
+        monkeypatch.setattr("claude_usage.get_usage", lambda claude_dir=None, timeout=60: fake_usage)
+
+        # Should not raise even with max_workers=1
+        results = get_usage_multi(["/a", "/b", "/c"], max_workers=1)
+        assert len(results) == 3
+
+    def test_all_failures_returns_all_none(self, monkeypatch):
+        def always_fail(claude_dir=None, timeout=60):
+            raise Exception("boom")
+
+        monkeypatch.setattr("claude_usage.get_usage", always_fail)
+
+        results = get_usage_multi(["/a", "/b"])
+        assert all(v is None for v in results.values())
+
+    def test_timeout_passed_through(self, monkeypatch):
+        captured = {}
+
+        def capture_timeout(claude_dir=None, timeout=60):
+            captured[claude_dir] = timeout
+            return Usage(five_hour_pct=1.0)
+
+        monkeypatch.setattr("claude_usage.get_usage", capture_timeout)
+
+        get_usage_multi(["/x", "/y"], timeout=30)
+        assert all(t == 30 for t in captured.values())
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: get_usage_multi (live)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestGetUsageMultiLive:
+    """Live integration tests for parallel usage checking."""
+
+    def test_multi_same_account(self, tmp_path):
+        """Probe the same account twice in parallel — results should agree."""
+        real_claude_dir = Path.home() / ".claude"
+        if not real_claude_dir.exists():
+            pytest.skip("~/.claude does not exist")
+
+        copy_a = tmp_path / "acct-a"
+        copy_b = tmp_path / "acct-b"
+        shutil.copytree(real_claude_dir, copy_a)
+        shutil.copytree(real_claude_dir, copy_b)
+
+        results = get_usage_multi([str(copy_a), str(copy_b)])
+        assert len(results) == 2
+
+        usages = [u for u in results.values() if u is not None]
+        assert len(usages) == 2
+
+        # Same account → 7-day should match within tolerance
+        if usages[0].seven_day_pct is not None and usages[1].seven_day_pct is not None:
+            assert abs(usages[0].seven_day_pct - usages[1].seven_day_pct) <= 2
+
+    def test_multi_with_bad_dir(self, tmp_path):
+        """One valid dir + one empty dir: valid should succeed, empty should be None."""
+        real_claude_dir = Path.home() / ".claude"
+        if not real_claude_dir.exists():
+            pytest.skip("~/.claude does not exist")
+
+        good = tmp_path / "good"
+        shutil.copytree(real_claude_dir, good)
+
+        bad = tmp_path / "bad"
+        bad.mkdir()
+
+        results = get_usage_multi([str(good), str(bad)], timeout=30)
+        assert results[str(good)] is not None
+        assert results[str(bad)] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `get_usage_multi()` that probes multiple `.claude` config dirs concurrently via `ThreadPoolExecutor` (default `min(N, 4)` workers)
- Individual failures return `None` without blocking other probes
- CLI `--claude-dir` is now repeatable; multiple values auto-route to parallel mode

Closes #1

## Test plan
- [x] 7 unit tests for `get_usage_multi()` (mocked `get_usage`, covering: dict keys, failure isolation, empty list, single dir, max_workers, all-fail, timeout passthrough)
- [x] 2 integration tests (`TestGetUsageMultiLive`: same-account parallel, mixed good/bad dir)
- [x] All 20 unit tests passing
- [ ] Manual test with real multi-account setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)